### PR TITLE
返却するエラーの改善

### DIFF
--- a/cavage_signer.go
+++ b/cavage_signer.go
@@ -66,7 +66,7 @@ func NewCavageSigner() *CavageSigner {
 // Passing nil opts is equivalent to passing a zero-value [CavageSignOptions].
 func (s *CavageSigner) SignRequest(req *http.Request, privateKey crypto.PrivateKey, keyId string, opts *CavageSignOptions) error {
 	if privateKey == nil {
-		return ErrMissingPrivateKey
+		return wrapSigreError(ErrMissingPrivateKey)
 	}
 	if opts == nil {
 		opts = &CavageSignOptions{}
@@ -85,22 +85,22 @@ func (s *CavageSigner) SignRequest(req *http.Request, privateKey crypto.PrivateK
 		effectiveKeyType = hs2019
 	}
 	if err := validateCreatedExpiresWithAlgorithm(headers, effectiveKeyType); err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	buf, created, expires, err := s.buildSigningString(req.Host, req.Method, req.URL, req.Header, headers, expiry)
 	if err != nil {
-		return fmt.Errorf("failed to create sign string: %w", err)
+		return wrapSigreError(fmt.Errorf("failed to create sign string: %w", err))
 	}
 
 	sig, keyType, err := s.signBytes(privateKey, opts, buf.Bytes())
 	if err != nil {
-		return fmt.Errorf("failed to create signature: %w", err)
+		return wrapSigreError(fmt.Errorf("failed to create signature: %w", err))
 	}
 
 	algoStr, err := s.algorithmString(opts.UseHS2019, keyType, opts.HashAlgorithm)
 	if err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	s.setSignatureHeader(req.Header, opts.SignatureHeader, cavageParams{
@@ -118,7 +118,7 @@ func (s *CavageSigner) SignRequest(req *http.Request, privateKey crypto.PrivateK
 // Passing nil opts is equivalent to passing a zero-value [CavageSignOptions].
 func (s *CavageSigner) SignRequestWithHMAC(req *http.Request, secret []byte, keyId string, opts *CavageSignOptions) error {
 	if len(secret) == 0 {
-		return ErrMissingSharedSecret
+		return wrapSigreError(ErrMissingSharedSecret)
 	}
 	if opts == nil {
 		opts = &CavageSignOptions{}
@@ -137,22 +137,22 @@ func (s *CavageSigner) SignRequestWithHMAC(req *http.Request, secret []byte, key
 		hmacKeyType = hs2019
 	}
 	if err := validateCreatedExpiresWithAlgorithm(headers, hmacKeyType); err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	buf, created, expires, err := s.buildSigningString(req.Host, req.Method, req.URL, req.Header, headers, expiry)
 	if err != nil {
-		return fmt.Errorf("failed to create sign string: %w", err)
+		return wrapSigreError(fmt.Errorf("failed to create sign string: %w", err))
 	}
 
 	sig, err := s.signHMAC(secret, buf.Bytes(), opts.HashAlgorithm)
 	if err != nil {
-		return fmt.Errorf("failed to create signature: %w", err)
+		return wrapSigreError(fmt.Errorf("failed to create signature: %w", err))
 	}
 
 	algoStr, err := s.hmacAlgorithmString(opts.UseHS2019, opts.HashAlgorithm)
 	if err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	s.setSignatureHeader(req.Header, opts.SignatureHeader, cavageParams{
@@ -170,7 +170,7 @@ func (s *CavageSigner) SignRequestWithHMAC(req *http.Request, secret []byte, key
 // Passing nil opts is equivalent to passing a zero-value [CavageSignOptions].
 func (s *CavageSigner) SignResponse(res *http.Response, privateKey crypto.PrivateKey, keyId string, opts *CavageSignOptions) error {
 	if privateKey == nil {
-		return ErrMissingPrivateKey
+		return wrapSigreError(ErrMissingPrivateKey)
 	}
 	if opts == nil {
 		opts = &CavageSignOptions{}
@@ -189,7 +189,7 @@ func (s *CavageSigner) SignResponse(res *http.Response, privateKey crypto.Privat
 		effectiveKeyType = hs2019
 	}
 	if err := validateCreatedExpiresWithAlgorithm(headers, effectiveKeyType); err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	var reqHost, reqMethod string
@@ -202,17 +202,17 @@ func (s *CavageSigner) SignResponse(res *http.Response, privateKey crypto.Privat
 
 	buf, created, expires, err := s.buildSigningString(reqHost, reqMethod, reqURL, res.Header, headers, expiry)
 	if err != nil {
-		return fmt.Errorf("failed to create sign string for response: %w", err)
+		return wrapSigreError(fmt.Errorf("failed to create sign string for response: %w", err))
 	}
 
 	sig, keyType, err := s.signBytes(privateKey, opts, buf.Bytes())
 	if err != nil {
-		return fmt.Errorf("failed to create signature for response: %w", err)
+		return wrapSigreError(fmt.Errorf("failed to create signature for response: %w", err))
 	}
 
 	algoStr, err := s.algorithmString(opts.UseHS2019, keyType, opts.HashAlgorithm)
 	if err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	s.setSignatureHeader(res.Header, opts.SignatureHeader, cavageParams{
@@ -230,7 +230,7 @@ func (s *CavageSigner) SignResponse(res *http.Response, privateKey crypto.Privat
 // Passing nil opts is equivalent to passing a zero-value [CavageSignOptions].
 func (s *CavageSigner) SignResponseWithHMAC(res *http.Response, secret []byte, keyId string, opts *CavageSignOptions) error {
 	if len(secret) == 0 {
-		return ErrMissingSharedSecret
+		return wrapSigreError(ErrMissingSharedSecret)
 	}
 	if opts == nil {
 		opts = &CavageSignOptions{}
@@ -249,7 +249,7 @@ func (s *CavageSigner) SignResponseWithHMAC(res *http.Response, secret []byte, k
 		hmacKeyType = hs2019
 	}
 	if err := validateCreatedExpiresWithAlgorithm(headers, hmacKeyType); err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	var reqHost, reqMethod string
@@ -262,17 +262,17 @@ func (s *CavageSigner) SignResponseWithHMAC(res *http.Response, secret []byte, k
 
 	buf, created, expires, err := s.buildSigningString(reqHost, reqMethod, reqURL, res.Header, headers, expiry)
 	if err != nil {
-		return fmt.Errorf("failed to create sign string for response: %w", err)
+		return wrapSigreError(fmt.Errorf("failed to create sign string for response: %w", err))
 	}
 
 	sig, err := s.signHMAC(secret, buf.Bytes(), opts.HashAlgorithm)
 	if err != nil {
-		return fmt.Errorf("failed to create signature for response: %w", err)
+		return wrapSigreError(fmt.Errorf("failed to create signature for response: %w", err))
 	}
 
 	algoStr, err := s.hmacAlgorithmString(opts.UseHS2019, opts.HashAlgorithm)
 	if err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	s.setSignatureHeader(res.Header, opts.SignatureHeader, cavageParams{

--- a/cavage_verifier.go
+++ b/cavage_verifier.go
@@ -41,11 +41,11 @@ type CavageVerifier struct {
 func NewCavageRequestVerifier(req *http.Request) (*CavageVerifier, error) {
 	hf := GetSignatureHeaderFields(req.Header)
 	if hf.Signature == "" {
-		return nil, &SigreError{Err: ErrMissingSignature}
+		return nil, wrapSigreError(ErrMissingSignature)
 	}
 	p, err := parseCavageParams(hf.Signature)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse HTTP signature parameters from request: %w", err)
+		return nil, wrapSigreError(fmt.Errorf("failed to parse HTTP signature parameters from request: %w", err))
 	}
 	return &CavageVerifier{
 		host:   req.Host,
@@ -61,11 +61,11 @@ func NewCavageRequestVerifier(req *http.Request) (*CavageVerifier, error) {
 func NewCavageResponseVerifier(res *http.Response) (*CavageVerifier, error) {
 	hf := GetSignatureHeaderFields(res.Header)
 	if hf.Signature == "" {
-		return nil, &SigreError{Err: ErrMissingSignature}
+		return nil, wrapSigreError(ErrMissingSignature)
 	}
 	p, err := parseCavageParams(hf.Signature)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse HTTP signature parameters from response: %w", err)
+		return nil, wrapSigreError(fmt.Errorf("failed to parse HTTP signature parameters from response: %w", err))
 	}
 
 	var host, method string
@@ -98,7 +98,7 @@ func (v *CavageVerifier) KeyId() string {
 // Passing nil opts is equivalent to passing a zero-value [VerifyOptions].
 func (v *CavageVerifier) Verify(key crypto.PublicKey, opts *VerifyOptions) error {
 	if key == nil {
-		return ErrMissingPublicKey
+		return wrapSigreError(ErrMissingPublicKey)
 	}
 	if opts == nil {
 		opts = &VerifyOptions{}
@@ -106,14 +106,14 @@ func (v *CavageVerifier) Verify(key crypto.PublicKey, opts *VerifyOptions) error
 
 	message, signature, keyType, hashesToTry, err := v.prepare(opts)
 	if err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	if keyType == "hmac" {
-		return fmt.Errorf("%w: signature algorithm is HMAC; use VerifyHMAC instead", ErrAlgorithmMismatch)
+		return wrapSigreError(fmt.Errorf("%w: signature algorithm is HMAC; use VerifyHMAC instead", ErrAlgorithmMismatch))
 	}
 
-	return verifyAsymmetric(key, keyType, signature, message, hashesToTry, v.params.Algorithm)
+	return wrapSigreError(verifyAsymmetric(key, keyType, signature, message, hashesToTry, v.params.Algorithm))
 }
 
 // VerifyHMAC checks an HMAC signature against secret.
@@ -121,7 +121,7 @@ func (v *CavageVerifier) Verify(key crypto.PublicKey, opts *VerifyOptions) error
 // Passing nil opts is equivalent to passing a zero-value [VerifyOptions].
 func (v *CavageVerifier) VerifyHMAC(secret []byte, opts *VerifyOptions) error {
 	if len(secret) == 0 {
-		return ErrMissingSharedSecret
+		return wrapSigreError(ErrMissingSharedSecret)
 	}
 	if opts == nil {
 		opts = &VerifyOptions{}
@@ -129,19 +129,19 @@ func (v *CavageVerifier) VerifyHMAC(secret []byte, opts *VerifyOptions) error {
 
 	message, signature, keyType, hashes, err := v.prepare(opts)
 	if err != nil {
-		return err
+		return wrapSigreError(err)
 	}
 
 	switch keyType {
 	case "hmac":
 		if len(hashes) != 1 {
-			return fmt.Errorf("HMAC verification requires exactly one hash algorithm, got %d from algorithm parameter '%s'", len(hashes), v.params.Algorithm)
+			return wrapSigreError(fmt.Errorf("HMAC verification requires exactly one hash algorithm, got %d from algorithm parameter '%s'", len(hashes), v.params.Algorithm))
 		}
 		h, err := getHash(hashes[0])
 		if err != nil {
-			return fmt.Errorf("unsupported hash '%s' for HMAC: %w", hashes[0], err)
+			return wrapSigreError(fmt.Errorf("unsupported hash '%s' for HMAC: %w", hashes[0], err))
 		}
-		return verifyHMAC(secret, signature, message, h)
+		return wrapSigreError(verifyHMAC(secret, signature, message, h))
 	case hs2019:
 		// algorithm="hs2019" or absent: try all supported hashes.
 		for _, name := range hashes {
@@ -153,9 +153,9 @@ func (v *CavageVerifier) VerifyHMAC(secret []byte, opts *VerifyOptions) error {
 				return nil
 			}
 		}
-		return fmt.Errorf("%w: HMAC verification failed for all hash algorithms", ErrVerification)
+		return wrapSigreError(fmt.Errorf("%w: HMAC verification failed for all hash algorithms", ErrVerification))
 	default:
-		return fmt.Errorf("%w: signature algorithm is '%s'; use Verify for asymmetric keys", ErrAlgorithmMismatch, keyType)
+		return wrapSigreError(fmt.Errorf("%w: signature algorithm is '%s'; use Verify for asymmetric keys", ErrAlgorithmMismatch, keyType))
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -39,6 +39,17 @@ type SigreError struct {
 	Err error
 }
 
+func wrapSigreError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var se *SigreError
+	if errors.As(err, &se) {
+		return err
+	}
+	return &SigreError{Err: err}
+}
+
 func (e *SigreError) Unwrap() error {
 	return e.Err
 }

--- a/sigre.go
+++ b/sigre.go
@@ -76,9 +76,9 @@ func NewRequestVerifier(req *http.Request) (Verifier, error) {
 	case CavageHTTPSignatures:
 		return NewCavageRequestVerifier(req)
 	case RFC9421:
-		return nil, &SigreError{Err: fmt.Errorf("RFC9421 verifier not implemented")}
+		return nil, wrapSigreError(fmt.Errorf("RFC9421 verifier not implemented"))
 	default:
-		return nil, &SigreError{Err: ErrMissingSignature}
+		return nil, wrapSigreError(ErrMissingSignature)
 	}
 }
 
@@ -94,8 +94,8 @@ func NewResponseVerifier(res *http.Response) (Verifier, error) {
 	case CavageHTTPSignatures:
 		return NewCavageResponseVerifier(res)
 	case RFC9421:
-		return nil, &SigreError{Err: fmt.Errorf("RFC9421 verifier not implemented")}
+		return nil, wrapSigreError(fmt.Errorf("RFC9421 verifier not implemented"))
 	default:
-		return nil, &SigreError{Err: ErrMissingSignature}
+		return nil, wrapSigreError(ErrMissingSignature)
 	}
 }


### PR DESCRIPTION
SigreErrorでラップして、本ライブラリー起因のエラーであることをチェックしやすくする。
また、多重ラップを防ぐ処理を新たに導入する。