### PR TITLE
CI改善

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,6 +16,10 @@ on:
       - "go.mod"
       - "go.sum"
       - ".github/workflows/ci-test.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,17 +28,28 @@ concurrency:
 jobs:
   golang-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.24.x"
+          go-version-file: go.mod
+          cache: true
+
+      - name: Show Go version
+        run: go version
+
       - name: Build
         run: go build
-      - run: go test ./... -v
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+
+      - name: Coverage summary
+        run: go tool cover -func=coverage.out


### PR DESCRIPTION
- actions/checkout、actions/setup-goのバージョンをハッシュで固定
- キャッシュ方法の変更
- Goのバージョンについて、go.modを参照するよう変更
- permissions: contents: read、workflow_dispatch、timeout-minutes: 10 を追加
- go vet、go test -race -covermode=atomic -coverprofile=coverage.out、coverage summary を追加